### PR TITLE
Update ESPHome-1P-Sunsynk-Deye.yaml to add energy meter phases and max solar power

### DIFF
--- a/ESPHome Configs/ESPHome-1P-Sunsynk-Deye.yaml
+++ b/ESPHome Configs/ESPHome-1P-Sunsynk-Deye.yaml
@@ -1186,11 +1186,20 @@ sensor:
 
 ################################################ SAVE RAW REGISTERS ############################################
 
-  - platform: modbus_controller            # 255 Grid Peak Shaving raw register value
+  - platform: modbus_controller            # 280 Grid Peak Shaving raw register value
     modbus_controller_id: inverter
     id: grid_peak_shaving_raw
     register_type: holding
     address: 280
+    value_type: U_WORD
+    internal: true
+    
+  - platform: modbus_controller            # 326 Advanced Function raw register value
+    modbus_controller_id: inverter
+    name: "Energy Meter # Phases Raw"
+    id: energy_meter_phases_raw
+    address: 326
+    register_type: holding
     value_type: U_WORD
     internal: true
 
@@ -1677,6 +1686,18 @@ number:
     max_value: 8000
     step: 500
     value_type: U_WORD
+    
+  - platform: modbus_controller            # 53 Max Solar Power
+    use_write_multiple: true
+    modbus_controller_id: inverter
+    name: "${friendly_name} Max Solar power"
+    id: inverter_max_solar_power
+    address: 53
+    unit_of_measurement: "W"
+    min_value: 0
+    max_value: 12000
+    step: 50
+    value_type: U_WORD
 
 ################################################ TEXT SENSORS ##################################################
 
@@ -1930,6 +1951,34 @@ select:
       // optionsmap should only return 2 values... 0 , 256 so bitmask with complement 0x0100 to ensure we keep the original values in register. Then appply OR with the value that was chosen
       uint16_t modified = ((unmodified & ~0x0100) | value);
       //ESP_LOGE("main","Modbus write to write = %d", modified);
+      return modified;
+      
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: inverter
+    name: "Energy Meter # Phases"
+    id: energy_meter_phases
+    address: 326
+    value_type: U_WORD
+    optionsmap:
+      "1": 0
+      "3": 12
+    lambda: |-
+      // Mask out bits 2+3
+      uint16_t masked = (x & 0x000C);
+
+      if (masked == 0) {
+        return std::string("1");
+      }
+      if (masked == 12) {
+        return std::string("3");
+      }
+      return {};
+    write_lambda: |-
+      // Preserve all other bits in register 326
+      uint16_t unmodified = id(energy_meter_phases_raw).state;
+      // Clear bits 2+3, then OR with chosen value (0 or 12)
+      uint16_t modified = ((unmodified & ~0x000C) | value);
       return modified;
 
   - platform: modbus_controller            #274 Select Prog1 Charge Option


### PR DESCRIPTION
Purpose

Add a new select sensor "Energy Meter # Phases" for inverter register 326 (0x0146), which configures how many phases are monitored by the energy meter.

Also add "max solar power" to limit input solar production

Background

The inverter is single-phase, but the grid connection is 3-phase.

Users may want to monitor either:

All 3 phases – to track total energy flow across the entire grid connection, useful for balancing total consumption.

Single phase – to track only the phase where the inverter is connected, allowing more precise load balancing for that phase.

Register 326 bits 2+3 control this selection:

0 → monitor 1 phase

12 → monitor 3 phases

Max solar production: user might want to stop solar and charge the batteries from grid instead, in case of negative dynamic pricing on the grid

Implementation

Added a raw sensor energy_meter_phases_raw to preserve all other bits in register 326.

Added a select entity "Energy Meter # Phases" showing 1 or 3, allowing users to choose the number of phases monitored by the energy meter.

Write operations only affect bits 2+3, preserving all other bits in the register.

This allows Home Assistant users to configure whether the energy meter tracks a single phase or the total three-phase connection, making load balancing and energy monitoring more flexible.

Max solar power added by cloning the "max sell power" definition.